### PR TITLE
[AMB-21] fix: reset chat stores on wallet change

### DIFF
--- a/src/components/button/WalletButton.tsx
+++ b/src/components/button/WalletButton.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/popover';
 import { useGetAllWalletsQuery } from '@/graphql/queries/__generated__/wallet.generated';
 import { cn } from '@/lib/utils';
+import { useChat, useContactStore } from '@/stores/contacts';
 import { LOCALSTORAGE_KEYS } from '@/utils/constants';
 import { ROUTES } from '@/utils/routes';
 
@@ -28,6 +29,9 @@ import { RefreshWallet } from './RefreshWallet';
 
 export function WalletButton() {
   const [open, setOpen] = useState(false);
+
+  const setCurrentContact = useContactStore(s => s.setCurrentContact);
+  const setCurrentPaymentOption = useChat(s => s.setCurrentPaymentOption);
 
   const { push } = useRouter();
 
@@ -92,6 +96,8 @@ export function WalletButton() {
                       setValue(currentValue);
                       push(ROUTES.app.home);
                       setOpen(false);
+                      setCurrentContact(undefined);
+                      setCurrentPaymentOption(undefined);
                     }}
                   >
                     {w.label}

--- a/src/stores/contacts.ts
+++ b/src/stores/contacts.ts
@@ -9,12 +9,12 @@ type Contact = {
 
 type ContactState = {
   currentContact: Contact | undefined;
-  setCurrentContact: (contact: Contact) => void;
+  setCurrentContact: (contact: Contact | undefined) => void;
 };
 
 export const useContactStore = create<ContactState>()(set => ({
   currentContact: undefined,
-  setCurrentContact: (contact: Contact) => set({ currentContact: contact }),
+  setCurrentContact: contact => set({ currentContact: contact }),
 }));
 
 export type PaymentOption = {


### PR DESCRIPTION
I also reset the payment option store because it seems related as well.