### PR TITLE
fix: only set initial document state on client

### DIFF
--- a/src/components/LanguageToggle.tsx
+++ b/src/components/LanguageToggle.tsx
@@ -30,7 +30,7 @@ export function LanguageToggle() {
   const { refresh } = useRouter();
 
   const [language, setLanguage] = useState<SupportedLanguage | undefined>(
-    getCookie()
+    typeof window !== 'undefined' ? getCookie() : undefined
   );
 
   return (


### PR DESCRIPTION
This should fix the server error logs that were showing up in DataDog.