### PR TITLE
fix: copy capital

### DIFF
--- a/src/views/landing/Believe.tsx
+++ b/src/views/landing/Believe.tsx
@@ -59,7 +59,7 @@ export const Believe = () => {
         />
         <Card
           title="4. Start banco-ing"
-          subtitle="Enjoy banking without boundaries and full control."
+          subtitle="Send money securely with complete freedom."
           image={womanCard}
         />
       </div>

--- a/src/views/landing/Why.tsx
+++ b/src/views/landing/Why.tsx
@@ -51,7 +51,7 @@ export const Why = () => {
           image={why3}
         />
         <Card
-          title="Private messaging"
+          title="Private Messaging"
           subtitle="Send encrypted messages to your contacts securely through Banco."
           image={why4}
         />


### PR DESCRIPTION
The other subtitles are all using captials so this will be consistent.

Also a copy update from @Jestopher-BTC.