### PR TITLE
[AMB-162] refactor: new transaction redesign view

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -24,6 +24,12 @@
         "tech-info": "Technical information about your wallet, helpful for advanced recovery.",
         "unlock": "Unlock to Decrypt"
       },
+      "Transactions": {
+        "ago": "ago",
+        "all": "All",
+        "no-results": "No results.",
+        "pending": "Pending"
+      },
       "Vault": {
         "lock": "Lock",
         "lock-wallet": "Lock your wallet",

--- a/messages/es.json
+++ b/messages/es.json
@@ -26,9 +26,9 @@
       },
       "Transactions": {
         "ago": "ago",
-        "all": "All",
-        "no-results": "No results.",
-        "pending": "Pending"
+        "all": "Todas",
+        "no-results": "Sin resultados.",
+        "pending": "Procesando"
       },
       "Vault": {
         "lock": "Bloquear",

--- a/messages/es.json
+++ b/messages/es.json
@@ -24,6 +24,12 @@
         "tech-info": "Información técnica sobre tu billetera, útil para recuperación avanzada.",
         "unlock": "Desbloquear para Desencriptar"
       },
+      "Transactions": {
+        "ago": "ago",
+        "all": "All",
+        "no-results": "No results.",
+        "pending": "Pending"
+      },
       "Vault": {
         "lock": "Bloquear",
         "lock-wallet": "Bloquear tu billetera",

--- a/src/components/button/RefreshButton.tsx
+++ b/src/components/button/RefreshButton.tsx
@@ -1,0 +1,37 @@
+import { RefreshCw } from 'lucide-react';
+import { useLocalStorage } from 'usehooks-ts';
+
+import { useRefreshWalletMutation } from '@/graphql/mutations/__generated__/refreshWallet.generated';
+import { cn } from '@/utils/cn';
+import { LOCALSTORAGE_KEYS } from '@/utils/constants';
+
+import { IconButton } from '../ui/button-v2';
+import { useToast } from '../ui/use-toast';
+
+export const RefreshButton = () => {
+  const { toast } = useToast();
+
+  const [value] = useLocalStorage(LOCALSTORAGE_KEYS.currentWalletId, '');
+
+  const [refresh, { loading: refreshLoading }] = useRefreshWalletMutation({
+    variables: { input: { wallet_id: value } },
+    refetchQueries: ['getWallet'],
+    onCompleted: () => toast({ title: 'Wallet Refreshed!' }),
+    onError: () =>
+      toast({
+        variant: 'destructive',
+        title: 'Error refeshing wallet.',
+      }),
+  });
+
+  return (
+    <IconButton
+      icon={
+        <RefreshCw size={20} className={cn(refreshLoading && 'animate-spin')} />
+      }
+      onClick={() => refresh()}
+      disabled={refreshLoading || !value}
+      className="z-10"
+    />
+  );
+};

--- a/src/components/button/RefreshButton.tsx
+++ b/src/components/button/RefreshButton.tsx
@@ -1,4 +1,5 @@
 import { RefreshCw } from 'lucide-react';
+import { FC } from 'react';
 import { useLocalStorage } from 'usehooks-ts';
 
 import { useRefreshWalletMutation } from '@/graphql/mutations/__generated__/refreshWallet.generated';
@@ -8,7 +9,7 @@ import { LOCALSTORAGE_KEYS } from '@/utils/constants';
 import { IconButton } from '../ui/button-v2';
 import { useToast } from '../ui/use-toast';
 
-export const RefreshButton = () => {
+export const RefreshButton: FC<{ className?: string }> = ({ className }) => {
   const { toast } = useToast();
 
   const [value] = useLocalStorage(LOCALSTORAGE_KEYS.currentWalletId, '');
@@ -31,7 +32,7 @@ export const RefreshButton = () => {
       }
       onClick={() => refresh()}
       disabled={refreshLoading || !value}
-      className="z-10"
+      className={className}
     />
   );
 };

--- a/src/views/transactions/TransactionsTable.tsx
+++ b/src/views/transactions/TransactionsTable.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import {
+  ColumnDef,
+  ColumnFiltersState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { SquareArrowLeft, SquareArrowRight } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Fragment, useMemo, useState } from 'react';
+
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/utils/cn';
+
+type TableProps<T> = {
+  data: T[];
+  columns: ColumnDef<T>[];
+  loading: boolean;
+};
+
+export const TransactionsTable = <T,>({
+  data,
+  columns,
+  loading,
+}: TableProps<T>): JSX.Element => {
+  const t = useTranslations();
+
+  const filterOptions = useMemo(
+    () => [t('App.Wallet.Transactions.all'), 'Liquid Bitcoin', 'Tether USD'],
+    [t]
+  );
+
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+
+  const table = useReactTable({
+    data,
+    columns,
+    onColumnFiltersChange: setColumnFilters,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    filterFns: {},
+    state: {
+      columnFilters,
+    },
+  });
+
+  return (
+    <div className="w-full max-w-[calc(100dvw-32px)]">
+      <div className="flex flex-wrap gap-2">
+        {filterOptions.map(o => (
+          <button
+            key={o}
+            onClick={() => {
+              if (o !== t('App.Wallet.Transactions.all')) {
+                table.getColumn('transaction')?.setFilterValue(o);
+              } else {
+                table.getColumn('transaction')?.setFilterValue('');
+              }
+            }}
+            disabled={loading}
+            className={cn(
+              'rounded-full border border-slate-200 px-3 py-1.5 font-medium text-foreground transition-all hover:border-foreground hover:bg-foreground hover:text-background disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-800',
+              ((!table.getState().columnFilters.length &&
+                o === t('App.Wallet.Transactions.all')) ||
+                table.getState().columnFilters[0]?.value === o) &&
+                'border-foreground bg-foreground text-background'
+            )}
+          >
+            {o}
+          </button>
+        ))}
+      </div>
+
+      <div className="my-4 space-y-3">
+        {loading ? (
+          Array.from({ length: 10 }).map((_, i) => (
+            <Skeleton key={i} className="h-[52px] w-full rounded-xl" />
+          ))
+        ) : (
+          <>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map(row => (
+                <Fragment key={row.id}>
+                  {row.getVisibleCells().map(cell => (
+                    <Fragment key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </Fragment>
+                  ))}
+                </Fragment>
+              ))
+            ) : (
+              <p className="font-semibold">
+                {t('App.Wallet.Transactions.no-results')}
+              </p>
+            )}
+          </>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between space-x-2">
+        <div className="text-sm text-slate-600 dark:text-neutral-400">
+          {loading ? null : (
+            <>
+              {table.getFilteredRowModel().rows.length}{' '}
+              {t('Index.transactions').slice(0, -1).toLowerCase()}(s)
+            </>
+          )}
+        </div>
+
+        <div className="flex items-center space-x-2">
+          <button
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage() || loading}
+            className="transition-opacity hover:opacity-75 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <SquareArrowLeft size={24} />
+          </button>
+
+          <button
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage() || loading}
+            className="transition-opacity hover:opacity-75 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <SquareArrowRight size={24} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/views/wallet/WalletInfo.tsx
+++ b/src/views/wallet/WalletInfo.tsx
@@ -9,7 +9,6 @@ import {
   Eye,
   EyeOff,
   Info,
-  RefreshCw,
   Settings2,
 } from 'lucide-react';
 import Image from 'next/image';
@@ -22,6 +21,7 @@ import smallCircular from '/public/icons/small-circular.svg';
 import smallCircularLight from '/public/icons/small-circular-light.svg';
 import liquid from '/public/images/liquid.jpg';
 import tether from '/public/images/tether.png';
+import { RefreshButton } from '@/components/button/RefreshButton';
 import { Button, IconButton } from '@/components/ui/button-v2';
 import { Card } from '@/components/ui/card';
 import {
@@ -42,7 +42,6 @@ import {
 } from '@/components/ui/drawer';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useToast } from '@/components/ui/use-toast';
-import { useRefreshWalletMutation } from '@/graphql/mutations/__generated__/refreshWallet.generated';
 import { useGetPricesHistoricalQuery } from '@/graphql/queries/__generated__/prices.generated';
 import { useGetWalletQuery } from '@/graphql/queries/__generated__/wallet.generated';
 import { cn } from '@/utils/cn';
@@ -168,17 +167,6 @@ export const WalletInfo: FC<{
         .toSorted((a, b) => Date.parse(b.date) - Date.parse(a.date)),
     [priceData]
   );
-
-  const [refresh, { loading: refreshLoading }] = useRefreshWalletMutation({
-    variables: { input: { wallet_id: id } },
-    refetchQueries: ['getWallet'],
-    onCompleted: () => toast({ title: 'Wallet Refreshed!' }),
-    onError: () =>
-      toast({
-        variant: 'destructive',
-        title: 'Error refeshing wallet.',
-      }),
-  });
 
   const balances = useMemo(() => {
     if (loading || error) return [];
@@ -541,7 +529,6 @@ export const WalletInfo: FC<{
       <div className="mb-3 flex w-full justify-between space-x-2">
         <button
           onClick={() => setView('assets')}
-          disabled={refreshLoading}
           className="z-10 h-fit font-semibold text-primary transition-colors hover:text-primary-hover"
         >
           {data?.wallets.find_one.name}
@@ -554,23 +541,12 @@ export const WalletInfo: FC<{
             className="z-10"
           />
 
-          <IconButton
-            icon={
-              <RefreshCw
-                size={20}
-                className={cn(refreshLoading && 'animate-spin')}
-              />
-            }
-            onClick={() => refresh()}
-            disabled={refreshLoading}
-            className="z-10"
-          />
+          <RefreshButton />
         </div>
       </div>
 
       <button
         onClick={() => setView('assets')}
-        disabled={refreshLoading}
         className="relative z-10 mb-1 text-4xl font-semibold"
       >
         {hideBalance ? '***' : totalBalance}

--- a/src/views/wallet/WalletInfo.tsx
+++ b/src/views/wallet/WalletInfo.tsx
@@ -541,7 +541,7 @@ export const WalletInfo: FC<{
             className="z-10"
           />
 
-          <RefreshButton />
+          <RefreshButton className="z-[1]" />
         </div>
       </div>
 


### PR DESCRIPTION
NOTE: Waiting on backend for a couple follow-up tasks but this can be merged before then. Coming later on will be:

- search + contact names (if it is decided to add contact name tx functionality into the backend)
- single detailed transaction view (when new query gets merged)
- recent transactions on the dashboard (when new query gets merged)

Already started conversation with @bufo24 about these items on Slack + created some Linear tasks for some of them.

![image](https://github.com/user-attachments/assets/f1a2f8b5-d4d8-490b-b40c-01a75091c97d)
